### PR TITLE
Fix the likers component API

### DIFF
--- a/src/likers/index.js
+++ b/src/likers/index.js
@@ -19,7 +19,7 @@ export default class BlueskyLikers extends BlueskyLikes {
 		await super.fetch({ force });
 
 		if (this.data.post) {
-			this.data.likers = await getPostLikes(this.src, { force });
+			this.data.likers = await getPostLikes(this.src, { force, limit: this.max });
 		}
 
 		return this.data;


### PR DESCRIPTION
- ~Clamp `max` so that the component doesn't choke on not allowed values~
- Consider `max` as an API call parameter