### PR TITLE
Ditch redundant null coalescing

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -72,7 +72,7 @@ export async function getPostUri (postUrl) {
 		return undefined;
 	}
 
-	let did = post.did ?? (await getDid(post.handle));
+	let did = await getDid(post.handle);
 
 	if (!did) {
 		return undefined;


### PR DESCRIPTION
`post` returned from `getPostUri` doesn't have a `did` property